### PR TITLE
Prevent negative absolute value of signed 32-bit hashcode

### DIFF
--- a/library/src/main/java/cn/carbs/android/avatarimageview/library/AvatarImageView.java
+++ b/library/src/main/java/cn/carbs/android/avatarimageview/library/AvatarImageView.java
@@ -273,7 +273,7 @@ public class AvatarImageView extends ImageView {
         if (TextUtils.isEmpty(seed)) {
             return COLORS[0];
         }
-        return COLORS[Math.abs(seed.hashCode()) % COLORS_NUMBER];
+        return COLORS[Math.abs(seed.hashCode() % COLORS_NUMBER)];
     }
 
     @Override


### PR DESCRIPTION
If the `hashCode()` method returns `Integer.MIN_VALUE`, the return of the `Math.abs` call will be negative (`Integer.MIN_VALUE`). This produces a negative modulo result, hence a negative array index for `COLORS`.

More details on this corner case [here](http://www.cs.umd.edu/~pugh/DevIgnition-Painful-puzzlers.pdf), slide 4 (called the _histogram mystery_).
